### PR TITLE
feat: visible projectile circles for ranged attacks (Phase B of #2)

### DIFF
--- a/src/config/troopTypes.ts
+++ b/src/config/troopTypes.ts
@@ -1,9 +1,9 @@
 import type { TroopType, TroopStats } from '../game/types';
 
 export const TROOP_TYPES: Record<TroopType, TroopStats> = {
-  base:   { walkSpeed: 80, hp: 100, damage: 20, attackInterval: 500, cost: 25, width: 24, height: 36, range: 60  },
-  archer: { walkSpeed: 80, hp: 80,  damage: 15, attackInterval: 350, cost: 35, width: 18, height: 30, range: 280 },
-  tank:   { walkSpeed: 50, hp: 250, damage: 30, attackInterval: 800, cost: 60, width: 32, height: 48, range: 50  },
+  base:   { walkSpeed: 80, hp: 100, damage: 20, attackInterval: 500, cost: 25, width: 24, height: 36, range: 60,  projectileSpeed: 600, projectileRadius: 5 },
+  archer: { walkSpeed: 80, hp: 80,  damage: 15, attackInterval: 350, cost: 35, width: 18, height: 30, range: 280, projectileSpeed: 800, projectileRadius: 4 },
+  tank:   { walkSpeed: 50, hp: 250, damage: 30, attackInterval: 800, cost: 60, width: 32, height: 48, range: 50,  projectileSpeed: 500, projectileRadius: 6 },
 };
 
 export const UNLOCK_COSTS: Partial<Record<TroopType, number>> = {

--- a/src/game/entities/Projectile.ts
+++ b/src/game/entities/Projectile.ts
@@ -1,0 +1,80 @@
+import Phaser from 'phaser';
+import { drawProjectile, type Side } from '../../render/shapes';
+import type { Damageable, TroopType } from '../types';
+import type { Troop } from './Troop';
+
+export interface ProjectileTarget extends Damageable {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+}
+
+export interface ProjectileImpact {
+  attacker: Troop;
+  attackerSide: Side;
+  target: ProjectileTarget;
+  damage: number;
+}
+
+export class Projectile {
+  private circle: Phaser.GameObjects.Arc;
+  private scene: Phaser.Scene;
+  expired = false;
+
+  readonly attacker: Troop;
+  readonly target: ProjectileTarget;
+  readonly damage: number;
+  readonly speed: number;
+  readonly attackerSide: Side;
+
+  constructor(scene: Phaser.Scene, attacker: Troop, target: ProjectileTarget, type: TroopType, speed: number) {
+    this.scene = scene;
+    this.attacker = attacker;
+    this.target = target;
+    this.damage = attacker.damage;
+    this.speed = speed;
+    this.attackerSide = attacker.side;
+    this.circle = drawProjectile(scene, attacker.side, type, attacker.x, attacker.y);
+  }
+
+  get x(): number {
+    return this.circle.x;
+  }
+
+  get y(): number {
+    return this.circle.y;
+  }
+
+  update(delta: number): void {
+    if (this.expired) return;
+    if (!this.target.isAlive()) {
+      this.expired = true;
+      return;
+    }
+
+    const dx = this.target.x - this.circle.x;
+    const dy = this.target.y - this.circle.y;
+    const dist = Math.hypot(dx, dy);
+    const step = this.speed * (delta / 1000);
+
+    if (dist <= this.target.width / 2 || dist <= step) {
+      this.target.takeDamage(this.damage);
+      const impact: ProjectileImpact = {
+        attacker: this.attacker,
+        attackerSide: this.attackerSide,
+        target: this.target,
+        damage: this.damage,
+      };
+      this.scene.events.emit('projectile:impact', impact);
+      this.expired = true;
+      return;
+    }
+
+    this.circle.x += (dx / dist) * step;
+    this.circle.y += (dy / dist) * step;
+  }
+
+  destroy(): void {
+    this.circle.destroy();
+  }
+}

--- a/src/game/entities/Tower.ts
+++ b/src/game/entities/Tower.ts
@@ -23,6 +23,10 @@ export class Tower implements Damageable {
     return this.rect.x;
   }
 
+  get y(): number {
+    return this.rect.y;
+  }
+
   get width(): number {
     return TOWER_WIDTH;
   }

--- a/src/game/entities/Troop.ts
+++ b/src/game/entities/Troop.ts
@@ -18,11 +18,13 @@ export class Troop implements Damageable {
   attackTimer: number = 0;
 
   readonly type: TroopType;
+  readonly side: Side;
 
   constructor(scene: Phaser.Scene, side: Side, type: TroopType, x: number, y: number, stats: TroopStats = TROOP_BASE) {
     this.scene = scene;
     this.stats = stats;
     this.type = type;
+    this.side = side;
     this.direction = side === 'player' ? 1 : -1;
     const hpBarYOffset = stats.height / 2 + 6;
     this.rect = drawTroop(scene, side, type, x, y);

--- a/src/game/scenes/MatchScene.ts
+++ b/src/game/scenes/MatchScene.ts
@@ -14,6 +14,7 @@ import { TROOP_TYPES } from '../../config/troopTypes';
 import { wavesForLevel, EMPTY_WAVES } from '../../config/enemyWaves';
 import { Troop } from '../entities/Troop';
 import { Tower } from '../entities/Tower';
+import { Projectile, type ProjectileTarget, type ProjectileImpact } from '../entities/Projectile';
 import { CombatSystem } from '../systems/CombatSystem';
 import { IncomeSystem } from '../systems/IncomeSystem';
 import { WaveSystem } from '../systems/WaveSystem';
@@ -28,13 +29,14 @@ import type { TroopType, MatchResult, MatchState, MatchWaveConfig } from '../typ
 export class MatchScene extends Phaser.Scene {
   playerTroops: Troop[] = [];
   enemyTroops: Troop[] = [];
+  projectiles: Projectile[] = [];
   playerTower!: Tower;
   enemyTower!: Tower;
   matchState: MatchState = { money: 0, troopDamageDealt: 0, towerDamageDealt: 0 };
   waveSystem!: WaveSystem;
   gameState!: GameState;
   private waveConfig: MatchWaveConfig = EMPTY_WAVES;
-  private combatSystem = new CombatSystem();
+  private combatSystem = new CombatSystem((attacker, target) => this.spawnProjectile(attacker, target));
   incomeSystem!: IncomeSystem;
   private overlay!: UpgradeScreen;
   private hud!: Hud;
@@ -68,7 +70,22 @@ export class MatchScene extends Phaser.Scene {
       (type) => this.handleHudSpawn(type),
       () => this.waveSystem,
     );
+    this.events.on('projectile:impact', (impact: ProjectileImpact) => this.onProjectileImpact(impact));
     this.matchEnded = false;
+  }
+
+  spawnProjectile(attacker: Troop, target: ProjectileTarget): void {
+    const stats = TROOP_TYPES[attacker.type];
+    this.projectiles.push(new Projectile(this, attacker, target, attacker.type, stats.projectileSpeed));
+  }
+
+  private onProjectileImpact(impact: ProjectileImpact): void {
+    if (impact.attackerSide !== 'player') return;
+    if (impact.target === this.enemyTower) {
+      this.matchState.towerDamageDealt += impact.damage;
+    } else if (this.enemyTroops.includes(impact.target as Troop)) {
+      this.matchState.troopDamageDealt += impact.damage;
+    }
   }
 
   spawnTroop(side: 'player' | 'enemy', type: TroopType): void {
@@ -98,7 +115,10 @@ export class MatchScene extends Phaser.Scene {
     this.playerTroops.forEach((t) => t.update(delta));
     this.enemyTroops.forEach((t) => t.update(delta));
 
-    this.combatSystem.update(delta, this.playerTroops, this.enemyTroops, this.playerTower, this.enemyTower, this.matchState);
+    this.combatSystem.update(delta, this.playerTroops, this.enemyTroops, this.playerTower, this.enemyTower);
+
+    this.projectiles.forEach((p) => p.update(delta));
+    this.projectiles = this.cleanupProjectiles(this.projectiles);
 
     this.playerTroops = this.cleanupTroops(this.playerTroops);
     this.enemyTroops = this.cleanupTroops(this.enemyTroops);
@@ -113,8 +133,10 @@ export class MatchScene extends Phaser.Scene {
   resetMatch(): void {
     this.playerTroops.forEach((t) => t.destroy());
     this.enemyTroops.forEach((t) => t.destroy());
+    this.projectiles.forEach((p) => p.destroy());
     this.playerTroops = [];
     this.enemyTroops = [];
+    this.projectiles = [];
     const playerMaxHp = effectiveValue(UPGRADES[1], TOWER.maxHp, this.gameState.upgrades.towerMaxHp);
     const incomeRate  = effectiveValue(UPGRADES[0], INCOME_RATE, this.gameState.upgrades.incomeRate);
     this.playerTower.resetHp(playerMaxHp);
@@ -159,6 +181,16 @@ export class MatchScene extends Phaser.Scene {
     return troops.filter((t) => {
       if (t.state === 'DEAD' || t.isOutOfBounds()) {
         t.destroy();
+        return false;
+      }
+      return true;
+    });
+  }
+
+  private cleanupProjectiles(projectiles: Projectile[]): Projectile[] {
+    return projectiles.filter((p) => {
+      if (p.expired) {
+        p.destroy();
         return false;
       }
       return true;

--- a/src/game/systems/CombatSystem.ts
+++ b/src/game/systems/CombatSystem.ts
@@ -1,6 +1,7 @@
 import type { Troop } from '../entities/Troop';
 import type { Tower } from '../entities/Tower';
-import type { Damageable, MatchState } from '../types';
+import type { ProjectileTarget } from '../entities/Projectile';
+import type { Damageable } from '../types';
 
 interface RangeTarget extends Damageable {
   x: number;
@@ -15,8 +16,8 @@ function pickTarget(
   self: Troop,
   troops: Troop[],
   tower: Tower,
-): Damageable | null {
-  let best: Damageable | null = null;
+): ProjectileTarget | null {
+  let best: ProjectileTarget | null = null;
   let bestDist = Infinity;
   for (const candidate of troops) {
     if (!candidate.isAlive()) continue;
@@ -37,13 +38,14 @@ function pickTarget(
 }
 
 export class CombatSystem {
+  constructor(private spawnProjectile: (attacker: Troop, target: ProjectileTarget) => void) {}
+
   update(
     delta: number,
     playerTroops: Troop[],
     enemyTroops: Troop[],
     playerTower: Tower,
     enemyTower: Tower,
-    matchState: MatchState,
   ): void {
     for (const player of playerTroops) {
       if (player.state !== 'WALKING') continue;
@@ -63,28 +65,12 @@ export class CombatSystem {
       }
     }
 
-    // Two-pass damage so mutual kills resolve in the same tick.
-    const pendingDamage = new Map<Damageable, number>();
-    const playerAttacks = new Set<Damageable>();
     for (const troop of [...playerTroops, ...enemyTroops]) {
       if (troop.state !== 'ATTACKING' || !troop.currentTarget) continue;
       troop.attackTimer += delta;
       if (troop.attackTimer >= troop.attackInterval) {
-        if (playerTroops.includes(troop)) playerAttacks.add(troop.currentTarget);
-        const current = pendingDamage.get(troop.currentTarget) ?? 0;
-        pendingDamage.set(troop.currentTarget, current + troop.damage);
+        this.spawnProjectile(troop, troop.currentTarget as ProjectileTarget);
         troop.attackTimer = 0;
-      }
-    }
-    const enemyTroopSet = new Set<Damageable>(enemyTroops);
-    for (const [target, damage] of pendingDamage) {
-      target.takeDamage(damage);
-      if (playerAttacks.has(target)) {
-        if (target === enemyTower) {
-          matchState.towerDamageDealt += damage;
-        } else if (enemyTroopSet.has(target)) {
-          matchState.troopDamageDealt += damage;
-        }
       }
     }
 

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -10,6 +10,8 @@ export interface TroopStats {
   attackInterval: number;
   cost: number;
   range: number;
+  projectileSpeed: number;
+  projectileRadius: number;
 }
 
 export interface MatchState {

--- a/src/render/shapes.ts
+++ b/src/render/shapes.ts
@@ -29,6 +29,19 @@ export function drawTroop(
   return scene.add.rectangle(x, y, stats.width, stats.height, color);
 }
 
+export function drawProjectile(
+  scene: Phaser.Scene,
+  side: Side,
+  type: TroopType,
+  x: number,
+  y: number,
+): Phaser.GameObjects.Arc {
+  const baseColor = side === 'player' ? TROOP_PLAYER : TROOP_ENEMY;
+  const color = shadeForType(baseColor, type);
+  const radius = TROOP_TYPES[type].projectileRadius;
+  return scene.add.circle(x, y, radius, color);
+}
+
 export interface HpBar {
   bg: Phaser.GameObjects.Rectangle;
   fill: Phaser.GameObjects.Rectangle;

--- a/tests/e2e/issue-2-projectiles.spec.ts
+++ b/tests/e2e/issue-2-projectiles.spec.ts
@@ -1,0 +1,244 @@
+import { test, expect, type Page } from '@playwright/test';
+import { TROOP_TYPES } from '../../src/config/troopTypes';
+
+type TroopShape = {
+  type: string;
+  x: number;
+  width: number;
+  state: string;
+  currentHp: number;
+  damage: number;
+  takeDamage: (n: number) => void;
+};
+
+type TowerShape = { x: number; width: number; currentHp: number };
+
+type ProjectileShape = {
+  attackerSide: 'player' | 'enemy';
+  damage: number;
+  expired: boolean;
+};
+
+type SceneShape = {
+  sys: { settings: { active: boolean } };
+  playerTroops: TroopShape[];
+  enemyTroops: TroopShape[];
+  playerTower: TowerShape;
+  enemyTower: TowerShape;
+  projectiles: ProjectileShape[];
+  matchState: { troopDamageDealt: number; towerDamageDealt: number; money: number };
+  spawnTroop: (side: string, type: string) => void;
+};
+
+type GameWindow = Window & {
+  __game__?: { scene: { getScene: (key: string) => SceneShape | null } };
+};
+
+async function waitForMatch(page: Page) {
+  await expect(page.locator('canvas')).toBeVisible({ timeout: 10_000 });
+  await page.waitForFunction(
+    () => (window as GameWindow).__game__?.scene.getScene('Match')?.sys.settings.active === true,
+    { timeout: 15_000 },
+  );
+}
+
+async function setUnlocks(page: Page, unlocks: string[]) {
+  await page.evaluate((u) => {
+    localStorage.setItem(
+      'towerincremental:save',
+      JSON.stringify({
+        version: 4,
+        data: {
+          enemyLevel: 1,
+          money: 0,
+          upgrades: { incomeRate: 0, towerMaxHp: 0 },
+          prestigeTier: 0,
+          unlockedTroopTypes: u,
+        },
+      }),
+    );
+  }, unlocks);
+}
+
+test('Firing creates projectiles', async ({ page }) => {
+  await page.goto('/?test');
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+  await waitForMatch(page);
+
+  await page.evaluate(() => {
+    const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+    scene?.spawnTroop('player', 'base');
+    scene?.spawnTroop('enemy', 'base');
+  });
+
+  await page.waitForFunction(
+    () => {
+      const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+      return (
+        scene?.playerTroops[0]?.state === 'ATTACKING' &&
+        scene?.enemyTroops[0]?.state === 'ATTACKING'
+      );
+    },
+    { timeout: 20_000 },
+  );
+
+  // Once both are attacking, a projectile should appear on the scene shortly.
+  await page.waitForFunction(
+    () => {
+      const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+      return (scene?.projectiles?.length ?? 0) >= 1;
+    },
+    { timeout: 5_000 },
+  );
+
+  const count = await page.evaluate(
+    () => (window as GameWindow).__game__?.scene.getScene('Match')?.projectiles.length ?? 0,
+  );
+  expect(count).toBeGreaterThanOrEqual(1);
+});
+
+test('Projectiles deal damage on impact', async ({ page }) => {
+  await page.goto('/?test');
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+  await waitForMatch(page);
+
+  await page.evaluate(() => {
+    const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+    scene?.spawnTroop('player', 'base');
+    scene?.spawnTroop('enemy', 'base');
+  });
+
+  // Wait until at least one projectile is in flight.
+  await page.waitForFunction(
+    () => {
+      const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+      return (scene?.projectiles?.length ?? 0) >= 1;
+    },
+    { timeout: 20_000 },
+  );
+
+  // Snapshot enemy HP and projectile count before impact resolves.
+  const before = await page.evaluate(() => {
+    const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+    return {
+      enemyHp: scene!.enemyTroops[0].currentHp,
+      enemyMax: scene!.enemyTroops[0].currentHp,
+      playerDamage: scene!.playerTroops[0].damage,
+    };
+  });
+
+  // Wait for the enemy HP to drop, indicating an impact landed.
+  await page.waitForFunction(
+    (initialHp) => {
+      const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+      return (scene?.enemyTroops[0]?.currentHp ?? initialHp) < initialHp;
+    },
+    before.enemyHp,
+    { timeout: 10_000 },
+  );
+
+  const after = await page.evaluate(() => {
+    const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+    return { enemyHp: scene!.enemyTroops[0].currentHp };
+  });
+
+  // Damage equal to a multiple of player base damage (a single impact's worth).
+  const dropped = before.enemyHp - after.enemyHp;
+  expect(dropped % before.playerDamage).toBe(0);
+  expect(dropped).toBeGreaterThanOrEqual(before.playerDamage);
+});
+
+test('Projectile cancels harmlessly when target dies in flight', async ({ page }) => {
+  await page.goto('/?test');
+  await setUnlocks(page, ['base', 'archer']);
+  await page.reload();
+  await waitForMatch(page);
+
+  await page.evaluate(() => {
+    const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+    scene?.spawnTroop('player', 'archer');
+    scene?.spawnTroop('enemy', 'base');
+  });
+
+  // Wait for a projectile to be in flight.
+  await page.waitForFunction(
+    () => {
+      const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+      return (scene?.projectiles?.length ?? 0) >= 1;
+    },
+    { timeout: 20_000 },
+  );
+
+  // Force-kill the enemy while a projectile is mid-flight.
+  await page.evaluate(() => {
+    const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+    scene!.enemyTroops[0].takeDamage(100000);
+  });
+
+  // The in-flight projectile must be removed (drops out of the array)
+  // and the player must return to WALKING — without crashing.
+  await page.waitForFunction(
+    () => {
+      const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+      return (scene?.projectiles?.length ?? 0) === 0;
+    },
+    { timeout: 5_000 },
+  );
+
+  const playerState = await page.evaluate(() => {
+    const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+    return scene!.playerTroops[0]?.state;
+  });
+  expect(playerState).toBe('WALKING');
+});
+
+test('Reward attribution still increments troopDamageDealt and towerDamageDealt', async ({ page }) => {
+  await page.goto('/?test');
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+  await waitForMatch(page);
+
+  // Player base vs enemy base — wait for the player's projectiles to chip the enemy.
+  await page.evaluate(() => {
+    const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+    scene?.spawnTroop('player', 'base');
+    scene?.spawnTroop('enemy', 'base');
+  });
+
+  await page.waitForFunction(
+    () => {
+      const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+      return (scene?.matchState.troopDamageDealt ?? 0) > 0;
+    },
+    { timeout: 20_000 },
+  );
+
+  const troopDamage = await page.evaluate(
+    () => (window as GameWindow).__game__?.scene.getScene('Match')?.matchState.troopDamageDealt ?? 0,
+  );
+  expect(troopDamage).toBeGreaterThanOrEqual(TROOP_TYPES.base.damage);
+
+  // Now reset and run a player vs enemy-tower scenario.
+  await page.evaluate(() => {
+    const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+    // Kill the enemy troop so player walks to the tower, then reset damage counters.
+    scene!.enemyTroops.forEach((t) => t.takeDamage(100000));
+    scene!.matchState.towerDamageDealt = 0;
+    scene?.spawnTroop('player', 'base');
+  });
+
+  await page.waitForFunction(
+    () => {
+      const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+      return (scene?.matchState.towerDamageDealt ?? 0) > 0;
+    },
+    { timeout: 30_000 },
+  );
+
+  const towerDamage = await page.evaluate(
+    () => (window as GameWindow).__game__?.scene.getScene('Match')?.matchState.towerDamageDealt ?? 0,
+  );
+  expect(towerDamage).toBeGreaterThanOrEqual(TROOP_TYPES.base.damage);
+});

--- a/tests/e2e/phase-2-troop-combat.spec.ts
+++ b/tests/e2e/phase-2-troop-combat.spec.ts
@@ -100,9 +100,15 @@ test('Two players both engage the same enemy — enemy dies faster, both players
     { timeout: 15_000 },
   );
 
-  // Enemy dies faster (2 attackers): 100hp / 40dmg_per_tick ≈ 3 ticks × 500ms = 1500ms
+  // Enemy dies faster (2 attackers): 100hp / 40dmg_per_tick ≈ 3 ticks × 500ms = 1500ms.
+  // After projectiles, the WALKING reset happens one tick after the kill, so wait for both.
   await page.waitForFunction(
-    () => (window as GameWindow).__game__?.scene.getScene('Match')?.enemyTroops.length === 0,
+    () => {
+      const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+      if (!scene) return false;
+      if (scene.enemyTroops.length !== 0) return false;
+      return scene.playerTroops.every((t) => t.state === 'WALKING');
+    },
     { timeout: 10_000 },
   );
 


### PR DESCRIPTION
## Summary
- Replaces Phase A's instant damage with visible circle projectiles that fly from attacker to target; damage applies on impact, projectiles expire harmlessly if target dies mid-flight
- Reward attribution (`troopDamageDealt` / `towerDamageDealt`) moves to a `projectile:impact` event so only player-attacker projectiles credit the bank
- Per-troop `projectileSpeed` and `projectileRadius` config; player vs enemy projectiles visually distinguished via existing palette + `shadeForType`

Closes #2.

## Test plan
- [x] New `tests/e2e/issue-2-projectiles.spec.ts` (4 tests) covers: projectile creation, damage on impact, cancel-on-target-death, reward attribution
- [x] Widened tolerance in `phase-2-troop-combat.spec.ts` mutual-engagement test to wait for the WALKING reset that follows projectile travel
- [x] Full e2e suite (67 tests) passes
- [x] 28 unit tests pass
- [x] `npm run lint`, `tsc --noEmit`, and `npm run build` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)