### PR TITLE
feat: lane band, spawn jitter, and 2D combat targeting (#12)

### DIFF
--- a/src/config/gameConfig.ts
+++ b/src/config/gameConfig.ts
@@ -4,6 +4,12 @@ import { TROOP_TYPES, UNLOCK_COSTS } from './troopTypes';
 export const BOARD_WIDTH = 1280;
 export const BOARD_HEIGHT = 720;
 
+// Vertical engagement zone: troops jitter within this band so the action stays visually concentrated.
+export const LANE_BAND = {
+  centerY: 360,
+  height: 200,
+} as const;
+
 export const TOWER_WIDTH = 60;
 export const TOWER_HEIGHT = 200;
 export const TOWER_MARGIN = 20;

--- a/src/game/scenes/MatchScene.ts
+++ b/src/game/scenes/MatchScene.ts
@@ -7,6 +7,7 @@ import {
   TOWER_WIDTH,
   INCOME_RATE,
   TOWER,
+  LANE_BAND,
   effectivePlayerStats,
   effectiveEnemyStats,
 } from '../../config/gameConfig';
@@ -103,7 +104,9 @@ export class MatchScene extends Phaser.Scene {
       side === 'player'
         ? TOWER_MARGIN + TOWER_WIDTH
         : BOARD_WIDTH - TOWER_MARGIN - TOWER_WIDTH;
-    const y = BOARD_HEIGHT / 2;
+    const y = window.location.search.includes('test')
+      ? LANE_BAND.centerY
+      : LANE_BAND.centerY + (Math.random() - 0.5) * LANE_BAND.height;
     const stats =
       side === 'enemy'
         ? effectiveEnemyStats(type, this.gameState.enemyLevel)

--- a/src/game/systems/CombatSystem.ts
+++ b/src/game/systems/CombatSystem.ts
@@ -5,19 +5,31 @@ import type { Damageable } from '../types';
 
 interface RangeTarget extends Damageable {
   x: number;
+  y: number;
   width: number;
 }
 
-function distanceToNearEdge(self: Troop, target: RangeTarget): number {
-  return Math.abs(self.x - target.x) - target.width / 2;
+interface RangeOrigin {
+  x: number;
+  y: number;
+  range: number;
 }
 
-function pickTarget(
-  self: Troop,
-  troops: Troop[],
-  tower: Tower,
-): ProjectileTarget | null {
-  let best: ProjectileTarget | null = null;
+export function distanceToNearEdge(
+  self: { x: number; y: number },
+  target: { x: number; y: number; width: number },
+): number {
+  const dx = self.x - target.x;
+  const dy = self.y - target.y;
+  return Math.hypot(dx, dy) - target.width / 2;
+}
+
+export function pickTarget(
+  self: RangeOrigin,
+  troops: RangeTarget[],
+  tower: RangeTarget,
+): RangeTarget | null {
+  let best: RangeTarget | null = null;
   let bestDist = Infinity;
   for (const candidate of troops) {
     if (!candidate.isAlive()) continue;

--- a/tests/unit/CombatSystem.test.ts
+++ b/tests/unit/CombatSystem.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { distanceToNearEdge, pickTarget } from '../../src/game/systems/CombatSystem';
+
+interface Mover {
+  x: number;
+  y: number;
+  range: number;
+}
+
+interface Target {
+  x: number;
+  y: number;
+  width: number;
+  alive: boolean;
+}
+
+function self(x: number, y: number, range: number = 1000): Mover {
+  return { x, y, range };
+}
+
+function target(x: number, y: number, width: number = 60, alive: boolean = true): Target {
+  return { x, y, width, alive };
+}
+
+function asRangeTarget(t: Target) {
+  return {
+    x: t.x,
+    y: t.y,
+    width: t.width,
+    isAlive: () => t.alive,
+    takeDamage: () => {},
+  };
+}
+
+describe('distanceToNearEdge', () => {
+  it('matches 1D behaviour when both are at the same Y', () => {
+    const s = self(100, 360);
+    const t = target(200, 360, 60);
+    // dx = 100, dy = 0 -> hypot = 100 -> 100 - 30 = 70
+    expect(distanceToNearEdge(s, t)).toBe(70);
+  });
+
+  it('returns greater distance when target is offset in Y', () => {
+    const s = self(100, 360);
+    const sameY = target(200, 360, 60);
+    const offsetY = target(200, 410, 60);
+    expect(distanceToNearEdge(s, offsetY)).toBeGreaterThan(distanceToNearEdge(s, sameY));
+  });
+
+  it('uses Math.hypot for the diagonal', () => {
+    const s = self(0, 0);
+    const t = target(30, 40, 0);
+    // 3-4-5 triangle, hypot = 50, width/2 = 0
+    expect(distanceToNearEdge(s, t)).toBeCloseTo(50);
+  });
+});
+
+describe('pickTarget', () => {
+  it('picks the target that is closer in 2D, even if X is farther', () => {
+    const attacker = self(100, 360, 500);
+    const xNearYFar = target(150, 460, 0); // dx=50, dy=100 -> ~111.8
+    const xFarYNear = target(180, 360, 0); // dx=80, dy=0   -> 80
+    const tower = {
+      x: 9999,
+      y: 360,
+      width: 60,
+      isAlive: () => true,
+      takeDamage: () => {},
+    };
+    const candidates = [asRangeTarget(xNearYFar), asRangeTarget(xFarYNear)];
+    const picked = pickTarget(attacker, candidates, tower);
+    expect(picked).toBe(candidates[1]);
+  });
+
+  it('returns null when no candidate is within range', () => {
+    const attacker = self(100, 360, 50);
+    const far = target(500, 360, 0);
+    const tower = {
+      x: 5000,
+      y: 360,
+      width: 60,
+      isAlive: () => true,
+      takeDamage: () => {},
+    };
+    expect(pickTarget(attacker, [asRangeTarget(far)], tower)).toBeNull();
+  });
+
+  it('picks tower when troops are out of range and tower is in range', () => {
+    const attacker = self(100, 360, 200);
+    const farTroop = target(500, 360, 0);
+    const tower = {
+      x: 250,
+      y: 360,
+      width: 60,
+      isAlive: () => true,
+      takeDamage: () => {},
+    };
+    const picked = pickTarget(attacker, [asRangeTarget(farTroop)], tower);
+    expect(picked).toBe(tower);
+  });
+
+  it('skips dead troops', () => {
+    const attacker = self(100, 360, 500);
+    const dead = target(150, 360, 0, false);
+    const alive = target(180, 360, 0, true);
+    const tower = {
+      x: 9999,
+      y: 360,
+      width: 60,
+      isAlive: () => true,
+      takeDamage: () => {},
+    };
+    const candidates = [asRangeTarget(dead), asRangeTarget(alive)];
+    const picked = pickTarget(attacker, candidates, tower);
+    expect(picked).toBe(candidates[1]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `LANE_BAND` constant (`centerY: 360, height: 200`) in `gameConfig.ts` and randomise troop spawn Y within it (deterministic under `?test` so e2e specs stay stable).
- `CombatSystem.distanceToNearEdge` now uses 2D distance via `Math.hypot`, so target selection considers Y as well as X.
- New unit tests in `tests/unit/CombatSystem.test.ts` cover same-Y, Y-offset, and 2D closer-target selection.

Phase 1 of #3 — foundational only; troops can still occupy the same X at different Y. Avoidance behaviour comes in phase 2.

Closes #12.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (35/35 unit)
- [x] `npm run test:e2e` (74/74)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)