### PR TITLE
feat: steering avoidance so troops form a wall (closes #3, #13)

### DIFF
--- a/src/config/gameConfig.ts
+++ b/src/config/gameConfig.ts
@@ -10,6 +10,11 @@ export const LANE_BAND = {
   height: 200,
 } as const;
 
+// Steering avoidance: friendly troops walking into a blocked friend slide sideways instead of stacking.
+export const AVOIDANCE_RADIUS = 40;
+export const AVOIDANCE_LOOK_AHEAD_X = 36;
+export const AVOIDANCE_SPEED = 60;
+
 export const TOWER_WIDTH = 60;
 export const TOWER_HEIGHT = 200;
 export const TOWER_MARGIN = 20;

--- a/src/game/entities/Troop.ts
+++ b/src/game/entities/Troop.ts
@@ -4,13 +4,16 @@ import { drawTroop, drawTroopHpBar, type HpBar } from '../../render/shapes';
 import type { Side } from '../../render/shapes';
 import type { TroopType, TroopState, TroopStats, Damageable } from '../types';
 
+let nextTroopId = 1;
+
 export class Troop implements Damageable {
   private rect: Phaser.GameObjects.Rectangle;
   private hpBar: HpBar;
-  private direction: number;
   private scene: Phaser.Scene;
   private stats: TroopStats;
 
+  readonly id: number;
+  readonly direction: number;
   state: TroopState = 'WALKING';
   currentHp: number;
   readonly maxHp: number;
@@ -25,6 +28,7 @@ export class Troop implements Damageable {
     this.stats = stats;
     this.type = type;
     this.side = side;
+    this.id = nextTroopId++;
     this.direction = side === 'player' ? 1 : -1;
     const hpBarYOffset = stats.height / 2 + 6;
     this.rect = drawTroop(scene, side, type, x, y);
@@ -39,6 +43,10 @@ export class Troop implements Damageable {
 
   get y(): number {
     return this.rect.y;
+  }
+
+  set y(value: number) {
+    this.rect.y = value;
   }
 
   get width(): number {

--- a/src/game/scenes/MatchScene.ts
+++ b/src/game/scenes/MatchScene.ts
@@ -105,9 +105,7 @@ export class MatchScene extends Phaser.Scene {
       side === 'player'
         ? TOWER_MARGIN + TOWER_WIDTH
         : BOARD_WIDTH - TOWER_MARGIN - TOWER_WIDTH;
-    const y = window.location.search.includes('test')
-      ? LANE_BAND.centerY
-      : LANE_BAND.centerY + (Math.random() - 0.5) * LANE_BAND.height;
+    const y = LANE_BAND.centerY;
     const stats =
       side === 'enemy'
         ? effectiveEnemyStats(type, this.gameState.enemyLevel)

--- a/src/game/scenes/MatchScene.ts
+++ b/src/game/scenes/MatchScene.ts
@@ -19,6 +19,7 @@ import { Projectile, type ProjectileTarget, type ProjectileImpact } from '../ent
 import { CombatSystem } from '../systems/CombatSystem';
 import { IncomeSystem } from '../systems/IncomeSystem';
 import { WaveSystem } from '../systems/WaveSystem';
+import { applyAvoidance } from '../systems/MovementSystem';
 import { computeReward } from '../systems/RewardSystem';
 import { MenuScreen } from '../../ui/MenuScreen';
 
@@ -124,6 +125,8 @@ export class MatchScene extends Phaser.Scene {
 
     this.incomeSystem.update(delta);
     this.waveSystem.update(delta);
+    applyAvoidance(this.playerTroops, delta);
+    applyAvoidance(this.enemyTroops, delta);
     this.playerTroops.forEach((t) => t.update(delta));
     this.enemyTroops.forEach((t) => t.update(delta));
 

--- a/src/game/systems/MovementSystem.ts
+++ b/src/game/systems/MovementSystem.ts
@@ -1,0 +1,46 @@
+import {
+  AVOIDANCE_LOOK_AHEAD_X,
+  AVOIDANCE_RADIUS,
+  AVOIDANCE_SPEED,
+  LANE_BAND,
+} from '../../config/gameConfig';
+import type { Troop } from '../entities/Troop';
+
+const LANE_MIN_Y = LANE_BAND.centerY - LANE_BAND.height / 2;
+const LANE_MAX_Y = LANE_BAND.centerY + LANE_BAND.height / 2;
+
+export function applyAvoidance(troops: Troop[], delta: number): void {
+  const dt = delta / 1000;
+
+  for (const t of troops) {
+    if (t.state !== 'WALKING') continue;
+
+    let lateral = 0;
+
+    for (const f of troops) {
+      if (f === t) continue;
+      if (f.state === 'DEAD') continue;
+
+      const ahead = t.direction === 1 ? f.x > t.x : f.x < t.x;
+      if (!ahead) continue;
+
+      const dx = f.x - t.x;
+      if (Math.abs(dx) > AVOIDANCE_LOOK_AHEAD_X) continue;
+
+      const dy = f.y - t.y;
+      const dist = Math.hypot(dx, dy);
+      if (dist > AVOIDANCE_RADIUS) continue;
+
+      const strength = 1 - dist / AVOIDANCE_RADIUS;
+      const diff = t.y - f.y;
+      const side = diff !== 0 ? Math.sign(diff) : (t.id % 2 === 0 ? 1 : -1);
+
+      lateral += side * strength * AVOIDANCE_SPEED * dt;
+    }
+
+    if (lateral !== 0) {
+      const next = t.y + lateral;
+      t.y = Math.max(LANE_MIN_Y, Math.min(LANE_MAX_Y, next));
+    }
+  }
+}

--- a/tests/e2e/issue-3-troops-dont-stack.spec.ts
+++ b/tests/e2e/issue-3-troops-dont-stack.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect, type Page } from '@playwright/test';
+import { LANE_BAND } from '../../src/config/gameConfig';
+
+type TroopShape = {
+  x: number;
+  y: number;
+  state: string;
+  type: string;
+};
+
+type SceneShape = {
+  sys: { settings: { active: boolean } };
+  playerTroops: TroopShape[];
+  enemyTroops: TroopShape[];
+  spawnTroop: (side: string, type: string) => void;
+};
+
+type GameWindow = Window & {
+  __game__?: { scene: { getScene: (key: string) => SceneShape | null } };
+};
+
+async function waitForMatch(page: Page) {
+  await page.goto('/?test');
+  await expect(page.locator('canvas')).toBeVisible({ timeout: 10_000 });
+  await page.waitForFunction(
+    () => (window as GameWindow).__game__?.scene.getScene('Match')?.sys.settings.active === true,
+    { timeout: 15_000 },
+  );
+}
+
+async function seedSave(
+  page: Page,
+  data: {
+    enemyLevel?: number;
+    money?: number;
+    upgrades?: { incomeRate: number; towerMaxHp: number };
+    prestigeTier?: number;
+    unlockedTroopTypes?: string[];
+  },
+) {
+  const full = {
+    enemyLevel: data.enemyLevel ?? 1,
+    money: data.money ?? 0,
+    upgrades: data.upgrades ?? { incomeRate: 0, towerMaxHp: 0 },
+    prestigeTier: data.prestigeTier ?? 0,
+    unlockedTroopTypes: data.unlockedTroopTypes ?? ['base'],
+  };
+  await page.evaluate((payload) => {
+    localStorage.setItem(
+      'towerincremental:save',
+      JSON.stringify({ version: 4, data: payload }),
+    );
+  }, full);
+}
+
+test('Five player troops form a wall — distinct Y positions, all inside the lane band', async ({ page }) => {
+  await waitForMatch(page);
+
+  // Spawn one enemy first, then 5 player troops in quick succession
+  await page.click('button:text("Spawn Enemy")');
+
+  for (let i = 0; i < 5; i++) {
+    await page.evaluate(() =>
+      (window as GameWindow).__game__?.scene.getScene('Match')?.spawnTroop('player', 'base'),
+    );
+  }
+
+  // Wait until at least one player troop is attacking the enemy
+  await page.waitForFunction(
+    () => {
+      const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+      if (!scene) return false;
+      if (scene.playerTroops.length < 5) return false;
+      return scene.playerTroops.some((t) => t.state === 'ATTACKING');
+    },
+    { timeout: 20_000 },
+  );
+
+  const ys = await page.evaluate(() => {
+    const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+    return scene?.playerTroops.map((t) => t.y) ?? [];
+  });
+
+  expect(ys).toHaveLength(5);
+
+  // All five Y positions are inside the lane band
+  const minY = LANE_BAND.centerY - LANE_BAND.height / 2;
+  const maxY = LANE_BAND.centerY + LANE_BAND.height / 2;
+  for (const y of ys) {
+    expect(y).toBeGreaterThanOrEqual(minY - 1);
+    expect(y).toBeLessThanOrEqual(maxY + 1);
+  }
+
+  // No two troops within ~5 px of each other in Y
+  for (let i = 0; i < ys.length; i++) {
+    for (let j = i + 1; j < ys.length; j++) {
+      expect(Math.abs(ys[i]! - ys[j]!)).toBeGreaterThan(5);
+    }
+  }
+});
+
+test('A single player troop with no friends does not jitter sideways', async ({ page }) => {
+  await waitForMatch(page);
+
+  await page.evaluate(() =>
+    (window as GameWindow).__game__?.scene.getScene('Match')?.spawnTroop('player', 'base'),
+  );
+
+  const y0 = await page.evaluate(
+    () => (window as GameWindow).__game__?.scene.getScene('Match')?.playerTroops[0]?.y ?? 0,
+  );
+
+  await page.waitForTimeout(1000);
+
+  const y1 = await page.evaluate(
+    () => (window as GameWindow).__game__?.scene.getScene('Match')?.playerTroops[0]?.y ?? 0,
+  );
+
+  expect(Math.abs(y1 - y0)).toBeLessThan(2);
+});
+
+test('Archer steps around base friend and ends up offset in Y when both engage', async ({ page }) => {
+  await page.goto('/?test');
+  await page.evaluate(() => localStorage.clear());
+  await seedSave(page, { unlockedTroopTypes: ['base', 'archer'] });
+  await page.reload();
+  await waitForMatch(page);
+
+  // Enemy at far end first
+  await page.click('button:text("Spawn Enemy")');
+
+  // Spawn base then archer close together
+  await page.evaluate(() =>
+    (window as GameWindow).__game__?.scene.getScene('Match')?.spawnTroop('player', 'base'),
+  );
+  await page.evaluate(() =>
+    (window as GameWindow).__game__?.scene.getScene('Match')?.spawnTroop('player', 'archer'),
+  );
+
+  // Wait until archer is ATTACKING (it has the longer range, so it engages first)
+  await page.waitForFunction(
+    () => {
+      const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+      if (!scene) return false;
+      const archer = scene.playerTroops.find((t) => t.type === 'archer');
+      return archer?.state === 'ATTACKING';
+    },
+    { timeout: 20_000 },
+  );
+
+  const positions = await page.evaluate(() => {
+    const scene = (window as GameWindow).__game__?.scene.getScene('Match');
+    const archer = scene?.playerTroops.find((t) => t.type === 'archer');
+    const base = scene?.playerTroops.find((t) => t.type === 'base');
+    return { archerY: archer?.y, baseY: base?.y };
+  });
+
+  expect(positions.archerY).toBeDefined();
+  expect(positions.baseY).toBeDefined();
+  expect(Math.abs(positions.archerY! - positions.baseY!)).toBeGreaterThan(5);
+});


### PR DESCRIPTION
## Summary
- Adds a `MovementSystem.applyAvoidance` that pushes WALKING troops sideways when a friendly is ahead within a look-ahead window, with a parity tie-breaker on stable troop id and a clamp to the lane band.
- Spawns all troops at `LANE_BAND.centerY` (no random Y jitter); the avoidance system fans them into a battle-line as they engage.
- New tunables in `gameConfig.ts`: `AVOIDANCE_RADIUS=40`, `AVOIDANCE_LOOK_AHEAD_X=36`, `AVOIDANCE_SPEED=60`.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (35/35)
- [x] `npm run test:e2e` (77/77, including the 3 new specs in `tests/e2e/issue-3-troops-dont-stack.spec.ts`)
- [x] `npm run build`

Closes #3.
Closes #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)