### PR TITLE
feat: settings page with advanced rebalance actions (#16)

### DIFF
--- a/src/game/scenes/MatchScene.ts
+++ b/src/game/scenes/MatchScene.ts
@@ -22,21 +22,31 @@ import { WaveSystem } from '../systems/WaveSystem';
 import { applyAvoidance } from '../systems/MovementSystem';
 import { computeReward } from '../systems/RewardSystem';
 import { MenuScreen } from '../../ui/MenuScreen';
+import { Hud } from '../../ui/Hud';
+import { UPGRADES, effectiveValue } from '../../config/upgradeConfig';
+import { load as loadSave, save as persistSave } from '../../state/SaveStore';
+import type { GameState } from '../../state/GameState';
 
 let sharedMenuScreen: MenuScreen | null = null;
+let sharedGameState: GameState | null = null;
 
 export function setSharedMenuScreen(menu: MenuScreen): void {
   sharedMenuScreen = menu;
+}
+
+export function setSharedGameState(state: GameState): void {
+  sharedGameState = state;
 }
 
 function getSharedMenuScreen(gameState: GameState): MenuScreen {
   if (!sharedMenuScreen) sharedMenuScreen = new MenuScreen(gameState);
   return sharedMenuScreen;
 }
-import { Hud } from '../../ui/Hud';
-import { UPGRADES, effectiveValue } from '../../config/upgradeConfig';
-import { load as loadSave, save as persistSave } from '../../state/SaveStore';
-import type { GameState } from '../../state/GameState';
+
+function getSharedGameState(): GameState {
+  if (!sharedGameState) sharedGameState = loadSave();
+  return sharedGameState;
+}
 import type { TroopType, MatchResult, MatchState, MatchWaveConfig } from '../types';
 
 export class MatchScene extends Phaser.Scene {
@@ -60,7 +70,7 @@ export class MatchScene extends Phaser.Scene {
   }
 
   create(): void {
-    this.gameState = loadSave();
+    this.gameState = getSharedGameState();
 
     this.add.rectangle(BOARD_WIDTH / 2, BOARD_HEIGHT / 2, BOARD_WIDTH, BOARD_HEIGHT, FIELD);
     const playerMaxHp = effectiveValue(UPGRADES[1], TOWER.maxHp, this.gameState.upgrades.towerMaxHp);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import Phaser from 'phaser';
 import { BootScene } from './game/scenes/BootScene';
-import { MatchScene, setSharedMenuScreen } from './game/scenes/MatchScene';
+import { MatchScene, setSharedMenuScreen, setSharedGameState } from './game/scenes/MatchScene';
 import { BOARD_WIDTH, BOARD_HEIGHT } from './config/gameConfig';
 import { createDebugSpawnButtons } from './ui/DebugSpawnButtons';
 import { LaunchController } from './ui/LaunchController';
@@ -28,6 +28,7 @@ if (import.meta.env.DEV || window.location.search.includes('test')) {
 
 if (!window.location.search.includes('test')) {
   const gameState = loadSave();
+  setSharedGameState(gameState);
   const launch = new LaunchController(game, gameState);
   setSharedMenuScreen(launch.menuScreen);
   launch.start();

--- a/src/ui/LaunchController.ts
+++ b/src/ui/LaunchController.ts
@@ -1,20 +1,25 @@
 import type Phaser from 'phaser';
 import type { GameState } from '../state/GameState';
 import { MenuScreen } from './MenuScreen';
+import { SettingsScreen } from './SettingsScreen';
 
 export class LaunchController {
   readonly menuScreen: MenuScreen;
+  readonly settingsScreen: SettingsScreen;
 
   constructor(
     private game: Phaser.Game,
     gameState: GameState,
   ) {
     this.menuScreen = new MenuScreen(gameState);
+    this.settingsScreen = new SettingsScreen(gameState);
   }
 
   start(): void {
     this.menuScreen.setContinueHandler(() => this.handleStart());
     this.menuScreen.setPrestigeHandler(() => this.handleStart());
+    this.menuScreen.setSettingsHandler(() => this.settingsScreen.show());
+    this.settingsScreen.setBackHandler(() => this.menuScreen.show());
     this.menuScreen.show();
   }
 

--- a/src/ui/MenuScreen.ts
+++ b/src/ui/MenuScreen.ts
@@ -25,8 +25,10 @@ export class MenuScreen {
   private rowsEl: HTMLDivElement;
   private primaryBtn: HTMLButtonElement;
   private prestigeBtn: HTMLButtonElement;
+  private settingsBtn: HTMLButtonElement;
   private onContinue: () => void = () => {};
   private onPrestige: () => void = () => {};
+  private onSettings: () => void = () => {};
 
   constructor(private gameState: GameState) {
     const existing = document.getElementById('match-result-overlay');
@@ -71,6 +73,15 @@ export class MenuScreen {
     this.prestigeBtn.id = 'upgrade-screen-prestige';
     this.prestigeBtn.addEventListener('click', () => this.handlePrestige());
 
+    this.settingsBtn = document.createElement('button');
+    this.settingsBtn.id = 'menu-screen-settings';
+    this.settingsBtn.textContent = 'Settings';
+    this.settingsBtn.style.cssText = 'font-size:16px;padding:8px 20px;cursor:pointer;';
+    this.settingsBtn.addEventListener('click', () => {
+      this.hide();
+      this.onSettings();
+    });
+
     this.el.appendChild(this.messageEl);
     this.el.appendChild(this.rewardEl);
     this.el.appendChild(this.bankEl);
@@ -79,6 +90,7 @@ export class MenuScreen {
     this.el.appendChild(this.rowsEl);
     this.el.appendChild(this.primaryBtn);
     this.el.appendChild(this.prestigeBtn);
+    this.el.appendChild(this.settingsBtn);
     document.body.appendChild(this.el);
   }
 
@@ -88,6 +100,10 @@ export class MenuScreen {
 
   setPrestigeHandler(fn: () => void): void {
     this.onPrestige = fn;
+  }
+
+  setSettingsHandler(fn: () => void): void {
+    this.onSettings = fn;
   }
 
   show(opts?: MenuShowOptions): void {

--- a/src/ui/SettingsScreen.ts
+++ b/src/ui/SettingsScreen.ts
@@ -1,0 +1,188 @@
+import { defaultGameState, type GameState } from '../state/GameState';
+import { save as persistSave, reset as resetSave } from '../state/SaveStore';
+import { showConfirmDialog } from './ConfirmDialog';
+
+export class SettingsScreen {
+  private el: HTMLDivElement;
+  private generalEl: HTMLDivElement;
+  private resetBtn: HTMLButtonElement;
+  private decreaseEnemyBtn: HTMLButtonElement;
+  private decreasePrestigeBtn: HTMLButtonElement;
+  private backBtn: HTMLButtonElement;
+  private onBack: () => void = () => {};
+
+  constructor(private gameState: GameState) {
+    const existing = document.getElementById('settings-screen');
+    if (existing) existing.remove();
+
+    this.el = document.createElement('div');
+    this.el.id = 'settings-screen';
+    this.el.style.cssText =
+      'display:none;position:fixed;inset:0;z-index:200;background:rgba(0,0,0,0.85);' +
+      'flex-direction:column;align-items:center;justify-content:center;gap:20px;padding:20px;';
+
+    const heading = document.createElement('h1');
+    heading.style.cssText = 'color:#fff;font-size:36px;margin:0;';
+    heading.textContent = 'Settings';
+
+    const generalSection = document.createElement('div');
+    generalSection.style.cssText =
+      'display:flex;flex-direction:column;gap:8px;min-width:360px;';
+    const generalHeading = document.createElement('h2');
+    generalHeading.style.cssText = 'color:#fff;font-size:22px;margin:0;';
+    generalHeading.textContent = 'General';
+    this.generalEl = document.createElement('div');
+    this.generalEl.id = 'settings-general';
+    this.generalEl.style.cssText =
+      'background:rgba(255,255,255,0.1);padding:16px;border-radius:8px;' +
+      'color:#aaa;font-size:14px;font-style:italic;text-align:center;';
+    this.generalEl.textContent = 'No general settings yet.';
+    generalSection.appendChild(generalHeading);
+    generalSection.appendChild(this.generalEl);
+
+    const advancedSection = document.createElement('div');
+    advancedSection.id = 'settings-advanced';
+    advancedSection.style.cssText =
+      'display:flex;flex-direction:column;gap:8px;min-width:360px;';
+    const advancedHeading = document.createElement('h2');
+    advancedHeading.style.cssText = 'color:#fff;font-size:22px;margin:0;';
+    advancedHeading.textContent = 'Advanced';
+
+    this.resetBtn = this.makeAdvancedButton('settings-reset-game');
+    this.resetBtn.addEventListener('click', () => this.handleReset());
+
+    this.decreaseEnemyBtn = this.makeAdvancedButton('settings-decrease-enemy-level');
+    this.decreaseEnemyBtn.addEventListener('click', () => this.handleDecreaseEnemy());
+
+    this.decreasePrestigeBtn = this.makeAdvancedButton('settings-decrease-prestige');
+    this.decreasePrestigeBtn.addEventListener('click', () => this.handleDecreasePrestige());
+
+    advancedSection.appendChild(advancedHeading);
+    advancedSection.appendChild(this.resetBtn);
+    advancedSection.appendChild(this.decreaseEnemyBtn);
+    advancedSection.appendChild(this.decreasePrestigeBtn);
+
+    this.backBtn = document.createElement('button');
+    this.backBtn.id = 'settings-back';
+    this.backBtn.textContent = 'Back';
+    this.backBtn.style.cssText = 'font-size:20px;padding:10px 28px;cursor:pointer;margin-top:12px;';
+    this.backBtn.addEventListener('click', () => {
+      this.hide();
+      this.onBack();
+    });
+
+    this.el.appendChild(heading);
+    this.el.appendChild(generalSection);
+    this.el.appendChild(advancedSection);
+    this.el.appendChild(this.backBtn);
+    document.body.appendChild(this.el);
+  }
+
+  setBackHandler(fn: () => void): void {
+    this.onBack = fn;
+  }
+
+  show(): void {
+    this.render();
+    this.el.style.display = 'flex';
+  }
+
+  hide(): void {
+    this.el.style.display = 'none';
+  }
+
+  isVisible(): boolean {
+    return this.el.style.display !== 'none';
+  }
+
+  private render(): void {
+    this.renderResetButton();
+    this.renderDecreaseEnemyButton();
+    this.renderDecreasePrestigeButton();
+  }
+
+  private renderResetButton(): void {
+    this.resetBtn.textContent = 'Reset game';
+    this.applyButtonStyle(this.resetBtn, true);
+  }
+
+  private renderDecreaseEnemyButton(): void {
+    const level = this.gameState.enemyLevel;
+    const enabled = level > 1;
+    this.decreaseEnemyBtn.textContent = `Decrease enemy level (current: ${level})`;
+    this.decreaseEnemyBtn.disabled = !enabled;
+    this.applyButtonStyle(this.decreaseEnemyBtn, enabled);
+  }
+
+  private renderDecreasePrestigeButton(): void {
+    const tier = this.gameState.prestigeTier;
+    const enabled = tier > 0;
+    this.decreasePrestigeBtn.textContent = `Decrease prestige (current: ${tier})`;
+    this.decreasePrestigeBtn.disabled = !enabled;
+    this.applyButtonStyle(this.decreasePrestigeBtn, enabled);
+  }
+
+  private async handleReset(): Promise<void> {
+    const confirmed = await showConfirmDialog({
+      id: 'settings-reset-confirm',
+      message: 'This will erase all progress and start a new game. Continue?',
+      confirmLabel: 'Reset',
+      cancelLabel: 'Cancel',
+    });
+    if (!confirmed) return;
+    resetSave();
+    const fresh = defaultGameState();
+    this.gameState.enemyLevel = fresh.enemyLevel;
+    this.gameState.money = fresh.money;
+    this.gameState.upgrades = { ...fresh.upgrades };
+    this.gameState.prestigeTier = fresh.prestigeTier;
+    this.gameState.unlockedTroopTypes = [...fresh.unlockedTroopTypes];
+    persistSave(this.gameState);
+    this.hide();
+    this.onBack();
+  }
+
+  private async handleDecreaseEnemy(): Promise<void> {
+    if (this.gameState.enemyLevel <= 1) return;
+    const target = this.gameState.enemyLevel - 1;
+    const confirmed = await showConfirmDialog({
+      id: 'settings-decrease-enemy-confirm',
+      message: `Decrease enemy level to ${target}?`,
+      confirmLabel: 'Decrease',
+      cancelLabel: 'Cancel',
+    });
+    if (!confirmed) return;
+    if (this.gameState.enemyLevel <= 1) return;
+    this.gameState.enemyLevel -= 1;
+    persistSave(this.gameState);
+    this.render();
+  }
+
+  private async handleDecreasePrestige(): Promise<void> {
+    if (this.gameState.prestigeTier <= 0) return;
+    const target = this.gameState.prestigeTier - 1;
+    const confirmed = await showConfirmDialog({
+      id: 'settings-decrease-prestige-confirm',
+      message: `Decrease prestige tier to ${target}?`,
+      confirmLabel: 'Decrease',
+      cancelLabel: 'Cancel',
+    });
+    if (!confirmed) return;
+    if (this.gameState.prestigeTier <= 0) return;
+    this.gameState.prestigeTier -= 1;
+    persistSave(this.gameState);
+    this.render();
+  }
+
+  private makeAdvancedButton(id: string): HTMLButtonElement {
+    const btn = document.createElement('button');
+    btn.id = id;
+    return btn;
+  }
+
+  private applyButtonStyle(btn: HTMLButtonElement, enabled: boolean): void {
+    btn.style.cssText =
+      `font-size:16px;padding:10px 16px;cursor:${enabled ? 'pointer' : 'not-allowed'};` +
+      `opacity:${enabled ? '1' : '0.5'};text-align:left;`;
+  }
+}

--- a/tests/e2e/issue-16-settings-page.spec.ts
+++ b/tests/e2e/issue-16-settings-page.spec.ts
@@ -1,0 +1,258 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function clearSave(page: Page) {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+}
+
+async function seedSave(
+  page: Page,
+  data: {
+    enemyLevel?: number;
+    money?: number;
+    upgrades?: { incomeRate: number; towerMaxHp: number };
+    prestigeTier?: number;
+    unlockedTroopTypes?: string[];
+  },
+) {
+  const full = {
+    enemyLevel: data.enemyLevel ?? 1,
+    money: data.money ?? 0,
+    upgrades: data.upgrades ?? { incomeRate: 0, towerMaxHp: 0 },
+    prestigeTier: data.prestigeTier ?? 0,
+    unlockedTroopTypes: data.unlockedTroopTypes ?? ['base'],
+  };
+  await page.evaluate((payload) => {
+    localStorage.setItem(
+      'towerincremental:save',
+      JSON.stringify({ version: 4, data: payload }),
+    );
+  }, full);
+}
+
+async function openSettings(page: Page) {
+  await expect(page.locator('#menu-screen-settings')).toBeVisible();
+  await page.locator('#menu-screen-settings').click();
+  await expect(page.locator('#settings-screen')).toBeVisible();
+}
+
+test('Settings button is visible on the main menu', async ({ page }) => {
+  await clearSave(page);
+  await page.reload();
+
+  await expect(page.locator('#menu-screen-settings')).toBeVisible();
+  await expect(page.locator('#menu-screen-settings')).toHaveText('Settings');
+});
+
+test('Clicking Settings opens the settings screen and hides the menu', async ({ page }) => {
+  await clearSave(page);
+  await page.reload();
+
+  await openSettings(page);
+  await expect(page.locator('#match-result-overlay')).toBeHidden();
+});
+
+test('Settings screen shows General and Advanced sections', async ({ page }) => {
+  await clearSave(page);
+  await page.reload();
+
+  await openSettings(page);
+  await expect(page.locator('#settings-general')).toBeVisible();
+  await expect(page.locator('#settings-advanced')).toBeVisible();
+  await expect(page.locator('#settings-reset-game')).toBeVisible();
+  await expect(page.locator('#settings-decrease-enemy-level')).toBeVisible();
+  await expect(page.locator('#settings-decrease-prestige')).toBeVisible();
+});
+
+test('Back button returns to the main menu', async ({ page }) => {
+  await clearSave(page);
+  await page.reload();
+
+  await openSettings(page);
+  await page.locator('#settings-back').click();
+
+  await expect(page.locator('#settings-screen')).toBeHidden();
+  await expect(page.locator('#match-result-overlay')).toBeVisible();
+  await expect(page.locator('#menu-screen-start')).toBeVisible();
+});
+
+test('Decrease enemy level button shows current value', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await seedSave(page, { enemyLevel: 5 });
+  await page.reload();
+
+  await openSettings(page);
+  await expect(page.locator('#settings-decrease-enemy-level')).toContainText('current: 5');
+});
+
+test('Decrease prestige button shows current value', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await seedSave(page, { prestigeTier: 3 });
+  await page.reload();
+
+  await openSettings(page);
+  await expect(page.locator('#settings-decrease-prestige')).toContainText('current: 3');
+});
+
+test('Decrease enemy level is disabled when enemyLevel === 1', async ({ page }) => {
+  await clearSave(page);
+  await page.reload();
+
+  await openSettings(page);
+  await expect(page.locator('#settings-decrease-enemy-level')).toBeDisabled();
+});
+
+test('Decrease prestige is disabled when prestigeTier === 0', async ({ page }) => {
+  await clearSave(page);
+  await page.reload();
+
+  await openSettings(page);
+  await expect(page.locator('#settings-decrease-prestige')).toBeDisabled();
+});
+
+test('Cancelling Reset game does nothing', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await seedSave(page, { enemyLevel: 5, money: 200, prestigeTier: 2 });
+  await page.reload();
+
+  await openSettings(page);
+  await page.locator('#settings-reset-game').click();
+  await expect(page.locator('#settings-reset-confirm')).toBeVisible();
+  await page.locator('#settings-reset-confirm .confirm-dialog-cancel').click();
+  await expect(page.locator('#settings-reset-confirm')).toHaveCount(0);
+
+  const stored = await page.evaluate(() => localStorage.getItem('towerincremental:save'));
+  const parsed = JSON.parse(stored!);
+  expect(parsed.data.enemyLevel).toBe(5);
+  expect(parsed.data.money).toBe(200);
+  expect(parsed.data.prestigeTier).toBe(2);
+});
+
+test('Confirming Reset game wipes save and the menu reflects the wipe', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await seedSave(page, {
+    enemyLevel: 5,
+    money: 200,
+    prestigeTier: 2,
+    upgrades: { incomeRate: 3, towerMaxHp: 2 },
+    unlockedTroopTypes: ['base', 'tank'],
+  });
+  await page.reload();
+
+  await openSettings(page);
+  await page.locator('#settings-reset-game').click();
+  await page.locator('#settings-reset-confirm .confirm-dialog-confirm').click();
+  await expect(page.locator('#settings-reset-confirm')).toHaveCount(0);
+
+  // Returns to menu and reflects defaults
+  await expect(page.locator('#menu-screen-enemy-level')).toContainText('Enemy Level: 1');
+  await expect(page.locator('#menu-screen-prestige-tier')).toContainText('Prestige Tier: 0');
+  await expect(page.locator('#upgrade-screen-bank')).toContainText('Bank: $0');
+
+  const stored = await page.evaluate(() => localStorage.getItem('towerincremental:save'));
+  const parsed = JSON.parse(stored!);
+  expect(parsed.data.enemyLevel).toBe(1);
+  expect(parsed.data.money).toBe(0);
+  expect(parsed.data.prestigeTier).toBe(0);
+  expect(parsed.data.upgrades).toEqual({ incomeRate: 0, towerMaxHp: 0 });
+  expect(parsed.data.unlockedTroopTypes).toEqual(['base']);
+});
+
+test('Cancelling Decrease enemy level does nothing', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await seedSave(page, { enemyLevel: 5 });
+  await page.reload();
+
+  await openSettings(page);
+  await page.locator('#settings-decrease-enemy-level').click();
+  await expect(page.locator('#settings-decrease-enemy-confirm')).toBeVisible();
+  await page.locator('#settings-decrease-enemy-confirm .confirm-dialog-cancel').click();
+  await expect(page.locator('#settings-decrease-enemy-confirm')).toHaveCount(0);
+
+  const stored = await page.evaluate(() => localStorage.getItem('towerincremental:save'));
+  const parsed = JSON.parse(stored!);
+  expect(parsed.data.enemyLevel).toBe(5);
+});
+
+test('Confirming Decrease enemy level decrements and persists', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await seedSave(page, { enemyLevel: 5 });
+  await page.reload();
+
+  await openSettings(page);
+  await page.locator('#settings-decrease-enemy-level').click();
+  await page.locator('#settings-decrease-enemy-confirm .confirm-dialog-confirm').click();
+  await expect(page.locator('#settings-decrease-enemy-confirm')).toHaveCount(0);
+
+  await expect(page.locator('#settings-decrease-enemy-level')).toContainText('current: 4');
+
+  const stored = await page.evaluate(() => localStorage.getItem('towerincremental:save'));
+  const parsed = JSON.parse(stored!);
+  expect(parsed.data.enemyLevel).toBe(4);
+
+  // Returning to menu reflects the change
+  await page.locator('#settings-back').click();
+  await expect(page.locator('#menu-screen-enemy-level')).toContainText('Enemy Level: 4');
+});
+
+test('Cancelling Decrease prestige does nothing', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await seedSave(page, { prestigeTier: 3 });
+  await page.reload();
+
+  await openSettings(page);
+  await page.locator('#settings-decrease-prestige').click();
+  await expect(page.locator('#settings-decrease-prestige-confirm')).toBeVisible();
+  await page.locator('#settings-decrease-prestige-confirm .confirm-dialog-cancel').click();
+  await expect(page.locator('#settings-decrease-prestige-confirm')).toHaveCount(0);
+
+  const stored = await page.evaluate(() => localStorage.getItem('towerincremental:save'));
+  const parsed = JSON.parse(stored!);
+  expect(parsed.data.prestigeTier).toBe(3);
+});
+
+test('Confirming Decrease prestige decrements and persists', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await seedSave(page, { prestigeTier: 3 });
+  await page.reload();
+
+  await openSettings(page);
+  await page.locator('#settings-decrease-prestige').click();
+  await page.locator('#settings-decrease-prestige-confirm .confirm-dialog-confirm').click();
+  await expect(page.locator('#settings-decrease-prestige-confirm')).toHaveCount(0);
+
+  await expect(page.locator('#settings-decrease-prestige')).toContainText('current: 2');
+
+  const stored = await page.evaluate(() => localStorage.getItem('towerincremental:save'));
+  const parsed = JSON.parse(stored!);
+  expect(parsed.data.prestigeTier).toBe(2);
+
+  await page.locator('#settings-back').click();
+  await expect(page.locator('#menu-screen-prestige-tier')).toContainText('Prestige Tier: 2');
+});
+
+test('State changes from settings persist across reload', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await seedSave(page, { enemyLevel: 5, prestigeTier: 3 });
+  await page.reload();
+
+  await openSettings(page);
+  await page.locator('#settings-decrease-enemy-level').click();
+  await page.locator('#settings-decrease-enemy-confirm .confirm-dialog-confirm').click();
+  await page.locator('#settings-decrease-prestige').click();
+  await page.locator('#settings-decrease-prestige-confirm .confirm-dialog-confirm').click();
+
+  await page.reload();
+
+  await expect(page.locator('#menu-screen-enemy-level')).toContainText('Enemy Level: 4');
+  await expect(page.locator('#menu-screen-prestige-tier')).toContainText('Prestige Tier: 2');
+});

--- a/tests/e2e/issue-16-settings-page.spec.ts
+++ b/tests/e2e/issue-16-settings-page.spec.ts
@@ -239,6 +239,58 @@ test('Confirming Decrease prestige decrements and persists', async ({ page }) =>
   await expect(page.locator('#menu-screen-prestige-tier')).toContainText('Prestige Tier: 2');
 });
 
+test('Settings reset propagates to in-match HUD when re-entering a match', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await seedSave(page, {
+    money: 500,
+    enemyLevel: 1,
+    unlockedTroopTypes: ['base', 'archer'],
+  });
+  await page.reload();
+
+  // Start a match — MatchScene.create() loads gameState
+  await expect(page.locator('#menu-screen-start')).toBeVisible();
+  await page.locator('#menu-screen-start').click();
+  await page.waitForFunction(
+    () =>
+      (window as unknown as {
+        __game__?: { scene: { getScene: (k: string) => { sys: { settings: { active: boolean } } } | null } };
+      }).__game__?.scene.getScene('Match')?.sys.settings.active === true,
+    { timeout: 10_000 },
+  );
+
+  // HUD reflects the seeded state mid-match
+  await expect(page.locator('#hud-bank')).toContainText('Bank: $500');
+  await expect(page.locator('#hud-spawn-archer')).toBeVisible();
+
+  // Force player win to surface the post-match menu
+  await page.evaluate(() => {
+    const game = (
+      window as unknown as {
+        __game__: { scene: { getScene: (k: string) => { enemyTower: { takeDamage: (n: number) => void } } } };
+      }
+    ).__game__;
+    game.scene.getScene('Match').enemyTower.takeDamage(99999);
+  });
+  await expect(page.locator('#match-result-overlay')).toBeVisible();
+
+  // Open Settings from the post-match overlay and reset the save
+  await page.locator('#menu-screen-settings').click();
+  await expect(page.locator('#settings-screen')).toBeVisible();
+  await page.locator('#settings-reset-game').click();
+  await page.locator('#settings-reset-confirm .confirm-dialog-confirm').click();
+
+  // Re-enter the match via the menu primary button
+  await expect(page.locator('#menu-screen-start')).toBeVisible();
+  await page.locator('#menu-screen-start').click();
+
+  // HUD must reflect the reset state, not the stale pre-reset state
+  await expect(page.locator('#hud-bank')).toContainText('Bank: $0');
+  await expect(page.locator('#hud-spawn-archer')).toHaveCount(0);
+  await expect(page.locator('#hud-spawn-base')).toBeVisible();
+});
+
 test('State changes from settings persist across reload', async ({ page }) => {
   await page.goto('/');
   await page.evaluate(() => localStorage.clear());


### PR DESCRIPTION
## Summary
- Adds a Settings screen accessible from the main menu with General (placeholder) and Advanced sections
- Advanced actions are confirm-gated: Reset game, Decrease enemy level, Decrease prestige
- Floors enforced: enemy level disabled at 1, prestige disabled at 0
- Shares a single `gameState` instance between the menu, settings screen, and match scene so resets propagate to the in-match HUD on re-entry

Closes #16

## Test plan
- [x] Unit tests pass (`npm run test`)
- [x] E2E tests pass (`npm run test:e2e`) — 93 passed, including 16 new settings specs
- [ ] Manual: open Settings from main menu and from post-match overlay
- [ ] Manual: reset game, then start a new match — HUD reflects reset bank and locked troops
- [ ] Manual: decrease enemy level / prestige with confirm dialogs; verify persistence across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)